### PR TITLE
fix: react-native-deprecated-custom-components use official npm version

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -26,7 +26,7 @@
     "react": "16.8.3",
     "react-addons-shallow-compare": "^15.6.2",
     "react-native": "0.59.10",
-    "react-native-deprecated-custom-components": "git+https://github.com/facebookarchive/react-native-custom-components.git#83c4fa19ccc9b6cd48ff80e457c493332819b486",
+    "react-native-deprecated-custom-components": "0.1.2",
     "react-native-gesture-handler": "1.8.0",
     "react-native-reanimated": "1.13.0",
     "react-native-safe-area-context": "3.1.7",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5658,9 +5658,10 @@ react-lifecycles-compat@^3.0.0:
   resolved "https://registry.npm.taobao.org/react-lifecycles-compat/download/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha1-TxonOv38jzSIqMUWv9p4+HI1I2I=
 
-"react-native-deprecated-custom-components@git+https://github.com/facebookarchive/react-native-custom-components.git#83c4fa19ccc9b6cd48ff80e457c493332819b486":
-  version "0.1.1"
-  resolved "git+https://github.com/facebookarchive/react-native-custom-components.git#83c4fa19ccc9b6cd48ff80e457c493332819b486"
+react-native-deprecated-custom-components@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npm.taobao.org/react-native-deprecated-custom-components/download/react-native-deprecated-custom-components-0.1.2.tgz#ba10d40942bd90e1a98f989fd2809ea2466d413f"
+  integrity sha1-uhDUCUK9kOGpj5if0oCeokZtQT8=
   dependencies:
     create-react-class "15.6.0"
     fbjs "~0.8.9"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.6.1",
     "react-addons-shallow-compare": "^15.6.2",
-    "react-native-deprecated-custom-components": "git+https://github.com/facebookarchive/react-native-custom-components.git#83c4fa19ccc9b6cd48ff80e457c493332819b486",
+    "react-native-deprecated-custom-components": "0.1.2",
     "react-native-gesture-handler": "1.8.0",
     "react-native-reanimated": "1.13.0",
     "react-native-safe-area-context": "3.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8471,9 +8471,10 @@ react-is@^16.3.1, react-is@^16.8.1, react-is@^16.8.6:
   resolved "https://registry.npm.taobao.org/react-is/download/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha1-LMD+D7p0LZf9UnxCoTvsTusGJBw=
 
-"react-native-deprecated-custom-components@git+https://github.com/facebookarchive/react-native-custom-components.git#83c4fa19ccc9b6cd48ff80e457c493332819b486":
-  version "0.1.1"
-  resolved "git+https://github.com/facebookarchive/react-native-custom-components.git#83c4fa19ccc9b6cd48ff80e457c493332819b486"
+react-native-deprecated-custom-components@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npm.taobao.org/react-native-deprecated-custom-components/download/react-native-deprecated-custom-components-0.1.2.tgz#ba10d40942bd90e1a98f989fd2809ea2466d413f"
+  integrity sha1-uhDUCUK9kOGpj5if0oCeokZtQT8=
   dependencies:
     create-react-class "15.6.0"
     fbjs "~0.8.9"


### PR DESCRIPTION
修复 react-native-deprecated-custom-components 使用 git commitId 存在无法安装的情况