### PR TITLE
feat(navigator): add bleRedirectOptions props

### DIFF
--- a/src/components/layout/full-view/index.js
+++ b/src/components/layout/full-view/index.js
@@ -51,6 +51,10 @@ class FullView extends Component {
     renderBleOfflineView: PropTypes.func,
     // wifi 离线的时候用户不想要重新连接跳转
     reconnectTextStyle: Text.propTypes.style,
+    /**
+     * @description 蓝牙离线弹框显示·查看更多·的跳转链接
+     */
+    bleRedirectOptions: PropTypes.object,
   };
 
   static defaultProps = {
@@ -67,6 +71,7 @@ class FullView extends Component {
     renderWifiOfflineView: null,
     renderBleOfflineView: null,
     reconnectTextStyle: null,
+    bleRedirectOptions: null,
   };
 
   constructor(props) {
@@ -211,6 +216,7 @@ class FullView extends Component {
       renderBleOfflineView,
       renderWifiOfflineView,
       reconnectTextStyle,
+      bleRedirectOptions,
     } = this.props;
     const show = !appOnline || !deviceOnline;
     const tipText = !appOnline
@@ -243,6 +249,7 @@ class FullView extends Component {
         renderWifiOfflineView={renderWifiOfflineView}
         renderBleOfflineView={renderBleOfflineView}
         reconnectTextStyle={reconnectTextStyle}
+        bleRedirectOptions={bleRedirectOptions}
       />
     );
   }

--- a/src/components/layout/navigator-layout/index.js
+++ b/src/components/layout/navigator-layout/index.js
@@ -266,6 +266,7 @@ export default class NavigatorLayout extends Component {
         renderWifiOfflineView={opts.renderWifiOfflineView}
         renderBleOfflineView={opts.renderBleOfflineView}
         reconnectTextStyle={opts.reconnectTextStyle}
+        bleRedirectOptions={opts.bleRedirectOptions}
       >
         {contentLayout}
       </FullView>

--- a/src/components/layout/offline-view/ble-offline-view/index.js
+++ b/src/components/layout/offline-view/ble-offline-view/index.js
@@ -48,6 +48,10 @@ export default class BleOfflineView extends Component {
      * 跳转链接
      */
     onLinkPress: PropTypes.func,
+    /**
+     * @description 蓝牙离线弹框显示·查看更多·的跳转链接
+     */
+    bleRedirectOptions: PropTypes.object,
   };
 
   static defaultProps = {
@@ -56,6 +60,7 @@ export default class BleOfflineView extends Component {
     isBleOfflineOverlay: true,
     isJumpToWifi: false,
     onLinkPress: () => {},
+    bleRedirectOptions: null,
   };
 
   componentDidMount() {
@@ -190,6 +195,7 @@ export default class BleOfflineView extends Component {
   };
 
   openH5HelpWebView = () => {
+    const { bleRedirectOptions } = this.props;
     Modal.close();
     TYSdk.Navigator.push({
       isOfflineWebView: true,
@@ -205,6 +211,7 @@ export default class BleOfflineView extends Component {
       },
       source: BLE_HELP_LINK,
       title: Strings.getLang('offlineHelp'),
+      ...bleRedirectOptions,
     });
   };
 

--- a/src/components/layout/offline-view/index.js
+++ b/src/components/layout/offline-view/index.js
@@ -41,6 +41,10 @@ export default class OfflineView extends Component {
     renderBleOfflineView: PropTypes.func,
     // wifi 离线的时候用户不想要重新连接跳转
     reconnectTextStyle: Text.propTypes.style,
+    /**
+     * @description 蓝牙离线弹框显示·查看更多·的跳转链接
+     */
+    bleRedirectOptions: PropTypes.object,
   };
 
   static defaultProps = {
@@ -56,6 +60,7 @@ export default class OfflineView extends Component {
     renderWifiOfflineView: null,
     renderBleOfflineView: null,
     reconnectTextStyle: null,
+    bleRedirectOptions: null,
   };
 
   state = {
@@ -126,7 +131,13 @@ export default class OfflineView extends Component {
   };
 
   renderBleView() {
-    const { deviceOnline, capability, isBleOfflineOverlay, renderBleOfflineView } = this.props;
+    const {
+      deviceOnline,
+      capability,
+      isBleOfflineOverlay,
+      renderBleOfflineView,
+      bleRedirectOptions,
+    } = this.props;
     const isJumpToWifi = this._handleVersionToJump();
     // 在蓝牙状态未获取到之前不渲染该页面
     if (typeof this.state.bluetoothStatus !== 'boolean') {
@@ -143,6 +154,7 @@ export default class OfflineView extends Component {
         isBleOfflineOverlay={isBleOfflineOverlay}
         isJumpToWifi={isJumpToWifi}
         onLinkPress={this._handleLinkPress}
+        bleRedirectOptions={bleRedirectOptions}
       />
     );
   }


### PR DESCRIPTION
# Pull Request Template

## Description

When the Bluetooth offline pop-up box is triggered, the button `check help` on the pop-up box will jump to the H5 page, and the new `bleRedirectOptions` support custom page

## Type of change

Please select the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
