### PR TITLE
fix(Offline): fixing a successful network allocation but showing devi…

### DIFF
--- a/src/components/layout/offline-view/index.js
+++ b/src/components/layout/offline-view/index.js
@@ -85,6 +85,7 @@ export default class OfflineView extends Component {
     const { devId } = TYSdk.devInfo;
     const isJumpToWifi = this._handleVersionToJump();
     if (isJumpToWifi) {
+      TYMobile.back();
       TYNative.jumpTo(`tuyaSmart://device_offline_reconnect?device_id=${devId}`);
     }
   };


### PR DESCRIPTION
## Description

The user clicks reconnect to trigger the re-matching process, and after the successful mapping, the app will add probe device B to the device list, because A and B are the same device, the cloud will send a command to remove probe device A from the device list when the mapping is successful, resulting in a pop-up window that the device has been removed.

## Type of change

Please select the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
