### PR TITLE
fix(Navigation): fix the flashback problem of transition animation mask

### DIFF
--- a/src/components/layout/react-navigation/TransitionPresets.js
+++ b/src/components/layout/react-navigation/TransitionPresets.js
@@ -43,8 +43,8 @@ const SlideFromRightWithMargin = {
     );
 
     const overlayOpacity = progress.interpolate({
-      inputRange: [0, 1, 1.0001, 2],
-      outputRange: [0, 0.3, 1, 1],
+      inputRange: [0, 0.3, 0.6, 1, 1.3, 1.7, 2],
+      outputRange: [0, 0.1, 0.2, 0.3, 0.2, 0.1, 0],
     });
 
     const statusBarHeight = insets.top - (isIos ? 44 : 0);
@@ -56,7 +56,6 @@ const SlideFromRightWithMargin = {
         borderTopLeftRadius: 10,
         borderTopRightRadius: 10,
         marginTop: statusBarHeight + topOffset,
-        marginBottom: topOffset,
         transform: [{ translateX: translateFocused }],
       },
       overlayStyle: { opacity: overlayOpacity },
@@ -105,8 +104,8 @@ export const ModalPresentationIOS = {
     );
 
     const overlayOpacity = progress.interpolate({
-      inputRange: [0, 1, 1.0001, 2],
-      outputRange: [0, 0.3, 1, 1],
+      inputRange: [0, 0.5, 0.9, 1, 2],
+      outputRange: [0, 0.1, 0.2, 0.3, 0.3],
     });
 
     const scale = isLandscape

--- a/src/components/layout/react-navigation/index.js
+++ b/src/components/layout/react-navigation/index.js
@@ -81,9 +81,6 @@ const Stack = createStackNavigator();
 
 export default function createNavigator({ router, screenOptions }) {
   const defaultScreenOptions = {
-    cardOverlay: () => {
-      return <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.3)' }} />;
-    },
     cardOverlayEnabled: true,
     ...TransitionPresets.SlideFromRightIOS,
   };


### PR DESCRIPTION
## Description

In the transition animation, when returning to the previous page, the mask flickers back and the visual over effect is not good.

## Type of change

Please select the relevant option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
