### PR TITLE
feat(bleOffline): H5 changeTo subPage

### DIFF
--- a/src/components/dialog/styled.js
+++ b/src/components/dialog/styled.js
@@ -99,6 +99,16 @@ export const StyledCancelButton = styled(TouchableOpacity).attrs({
   background-color: ${props => (props.pressActive ? pressColor : bgColor)};
 `;
 
+export const StyledButton = styled(TouchableOpacity).attrs({
+  activeOpacity: 0.8,
+})`
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  border-right-width: ${props => (props.bordered ? StyleSheet.hairlineWidth : 0)};
+  border-right-color: ${lineColor};
+`;
+
 export const StyledCancelText = styled(TYText)`
   font-size: ${cancelFontSize}px;
   text-align: center;

--- a/src/components/layout/offline-view/ble-offline-view/index.js
+++ b/src/components/layout/offline-view/ble-offline-view/index.js
@@ -1,19 +1,17 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { View } from 'react-native';
 import { TYSdk } from '../../../../TYNativeApi';
 import Modal from '../../../modal';
-import H5WebView from '../webview';
 import BleToast from './ble-toast';
 import BleToastModal from './ble-toast-modal'; // 安卓开启蓝牙Toast提示框
 import BleTipModal from './ble-tip-modal'; // IOS开启蓝牙弹窗提示框
 import BleOfflineModal from './ble-offline-modal';
 import Strings from '../../../i18n/strings';
-import { CoreUtils, RatioUtils } from '../../../../utils';
+import { RatioUtils } from '../../../../utils';
 import { StyledTitle, StyledCancelText } from './styled';
 import { StyledFooter, StyledButton, StyledConfirmText } from '../../../dialog/styled';
 
-const { get } = CoreUtils;
 const { isIos } = RatioUtils;
 
 const TYDevice = TYSdk.device;
@@ -23,8 +21,6 @@ const Res = {
   arrow: require('../../../res/arrow.png'),
   question: require('../../../res/question.png'),
 };
-
-const BLE_HELP_LINK = 'https://smartapp.tuya.com/faq/mesh1';
 
 export default class BleOfflineView extends Component {
   static propTypes = {
@@ -118,14 +114,8 @@ export default class BleOfflineView extends Component {
         TYDevice.gotoBlePermissions();
       }
     } else if (!deviceOnline) {
-      const routes =
-        TYSdk.Navigator && TYSdk.Navigator.getCurrentRoutes && TYSdk.Navigator.getCurrentRoutes();
-      const isOfflineWebView = get(routes, `${routes.length - 1}.isOfflineWebView`, false);
       // 处理一直在 webView 页面弹框无法关闭 Toast 问题
       Modal.close();
-      if (isOfflineWebView) {
-        return;
-      }
       this.showBleOfflineModal();
     }
   };
@@ -195,21 +185,8 @@ export default class BleOfflineView extends Component {
 
   openH5HelpWebView = () => {
     Modal.close();
-    TYSdk.Navigator.push({
-      isOfflineWebView: true,
-      element: H5WebView,
-      hideFullView: true,
-      barStyle: 'default',
-      titleStyle: { color: '#000' },
-      appStyle: { backgroundColor: '#fff' },
-      topBarStyle: {
-        borderBottomWidth: StyleSheet.hairlineWidth,
-        borderBottomColor: '#E1E1E1',
-        backgroundColor: '#fff',
-      },
-      source: BLE_HELP_LINK,
-      title: Strings.getLang('offlineHelp'),
-    });
+    // 蓝牙离线二级页面
+    TYSdk.mobile.jumpSubPage({ uiId: '0000012lky' }, {});
   };
 
   _handleToastPress = () => {

--- a/src/components/layout/react-navigation/index.js
+++ b/src/components/layout/react-navigation/index.js
@@ -356,6 +356,7 @@ export default function createNavigator({ router, screenOptions }) {
               initialRouteName="main"
               screenOptions={({ route, navigation }) => {
                 this._navigation = navigation;
+                TYSdk.applyNavigator(navigation);
                 const options = this.getScreenOptions(
                   { route, navigation },
                   screenOptions,


### PR DESCRIPTION
## Description

When the device Bluetooth is offline, the offline pop-up form is replaced by jumping H5 pages to jump secondary pages, reducing the project development burden.

## Type of change

Please select the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
