### PR TITLE
style(TYFlatList): set showsVerticalScrollIndicator = false

### DIFF
--- a/src/components/TYLists/list.js
+++ b/src/components/TYLists/list.js
@@ -136,6 +136,7 @@ export default class TYFlatList extends Component {
               renderItem={this.renderItem}
               data={data}
               keyExtractor={item => item.key}
+              showsVerticalScrollIndicator={false}
               {...flatListProps}
               ref={flatListRef}
             />

--- a/src/components/TYLists/lists.js
+++ b/src/components/TYLists/lists.js
@@ -175,6 +175,7 @@ export default class TYSectionLists extends Component {
               sections={sections}
               keyExtractor={item => item.key}
               stickySectionHeadersEnabled={false}
+              showsVerticalScrollIndicator={false}
               {...sectionListProps}
               ref={sectionListRef}
             />


### PR DESCRIPTION
## Description

Sets the default value of showsVerticalScrollIndicator to false.

## Type of change

Please select the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Style (Modify default style)
