### PR TITLE
feat(Tabbar): radiobutton use props textStyle

### DIFF
--- a/packages/tuya-panel-kit/src/components/tabbar/__tests__/__snapshots__/tabbar.test.js.snap
+++ b/packages/tuya-panel-kit/src/components/tabbar/__tests__/__snapshots__/tabbar.test.js.snap
@@ -695,6 +695,9 @@ exports[`Tabbar Component type radio 1`] = `
                   },
                 ],
                 Object {
+                  "color": "#F84803",
+                },
+                Object {
                   "fontSize": 16,
                 },
               ],
@@ -757,6 +760,9 @@ exports[`Tabbar Component type radio 1`] = `
                   },
                 ],
                 Object {
+                  "color": "#F84803",
+                },
+                Object {
                   "fontSize": 16,
                 },
               ],
@@ -764,7 +770,9 @@ exports[`Tabbar Component type radio 1`] = `
                 "color": "#57BCFB",
                 "fontWeight": "500",
               },
-              Object {},
+              Object {
+                "color": "#F84803",
+              },
             ],
           ]
         }
@@ -821,6 +829,9 @@ exports[`Tabbar Component type radio 1`] = `
                     "opacity": 0,
                   },
                 ],
+                Object {
+                  "color": "#F84803",
+                },
                 Object {
                   "fontSize": 16,
                 },
@@ -897,7 +908,9 @@ exports[`Tabbar Component type radioCircle 1`] = `
               "height": 4,
               "width": 4,
             },
-            Object {},
+            Object {
+              "backgroundColor": "#F84803",
+            },
           ]
         }
       />
@@ -950,6 +963,9 @@ exports[`Tabbar Component type radioCircle 1`] = `
                   },
                 ],
                 Object {
+                  "color": "#F84803",
+                },
+                Object {
                   "fontSize": 16,
                 },
               ],
@@ -957,7 +973,9 @@ exports[`Tabbar Component type radioCircle 1`] = `
                 "color": "#57BCFB",
                 "fontWeight": "500",
               },
-              Object {},
+              Object {
+                "color": "#F84803",
+              },
             ],
           ]
         }
@@ -994,7 +1012,9 @@ exports[`Tabbar Component type radioCircle 1`] = `
               "height": 4,
               "width": 4,
             },
-            Object {},
+            Object {
+              "backgroundColor": "#F84803",
+            },
           ]
         }
       />

--- a/packages/tuya-panel-kit/src/components/tabbar/__tests__/tabbar.test.js
+++ b/packages/tuya-panel-kit/src/components/tabbar/__tests__/tabbar.test.js
@@ -110,6 +110,12 @@ describe('Tabbar Component', () => {
       .create(
         <TabBar
           type="radio"
+          tabTextStyle={{
+            color: '#F84803',
+          }}
+          tabActiveTextStyle={{
+            color: '#F84803',
+          }}
           tabs={tabRadios}
           activeKey="2"
           onChange={jest.fn()}
@@ -132,6 +138,12 @@ describe('Tabbar Component', () => {
       .create(
         <TabBar
           type="radioCircle"
+          tabTextStyle={{
+            color: '#F84803',
+          }}
+          tabActiveTextStyle={{
+            color: '#F84803',
+          }}
           tabs={tabRadios}
           activeKey="2"
           onChange={jest.fn()}

--- a/packages/tuya-panel-kit/src/components/tabbar/radio-button/group.js
+++ b/packages/tuya-panel-kit/src/components/tabbar/radio-button/group.js
@@ -70,25 +70,29 @@ class Group extends React.PureComponent {
   }
 
   getItem = () => {
-    const { tabs, type } = this.props;
+    const { tabs, type, tabTextStyle, tabActiveTextStyle } = this.props;
     const buttonStyle = [{ width: this.state.wrapperWidth / tabs.length }];
     const defaultTextStyle = [{ opacity: this.state.activeViewHidden ? 0 : 1 }];
+    const circleStyle = tabTextStyle && tabTextStyle.color && { backgroundColor: tabTextStyle.color }
     return tabs.map((item, index) => {
       const { style, textStyle, ...other } = item;
       return (
         <RadioButton
+          activeTextStyle={tabActiveTextStyle}
+          circleStyle={circleStyle}
           {...other}
           // eslint-disable-next-line react/no-array-index-key
           key={`tab_${index}`}
           type={type}
           style={[buttonStyle, style]}
-          textStyle={[defaultTextStyle, textStyle]}
+          textStyle={[defaultTextStyle, tabTextStyle, textStyle]}
           onItemPress={() => this.changeTab(index, item, item.onItemPress)}
           isActive={this.state.activeIndex === index}
         />
       );
     });
   };
+
   moveActiveView = index => {
     const { gutter } = this.props;
     const currentLeft = index * this.state.everyWidth + gutter;


### PR DESCRIPTION
## Description

TabBarProps tabActiveTextStyle is no working with radio type.

## Type of change

Please select the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
