### PR TITLE
fix(Popup.countdown): when onlyone is true, the picker is not center

### DIFF
--- a/packages/tuya-panel-kit/src/components/popup/__tests__/__snapshots__/countdown.test.js.snap
+++ b/packages/tuya-panel-kit/src/components/popup/__tests__/__snapshots__/countdown.test.js.snap
@@ -6116,10 +6116,6 @@ exports[`countdown Component render width onlyone 1`] = `
               "alignItems": "center",
               "backgroundColor": "#fff",
               "flexDirection": "row",
-              "marginBottom": 0,
-              "marginLeft": 30,
-              "marginRight": 30,
-              "marginTop": 0,
             },
             undefined,
           ]

--- a/packages/tuya-panel-kit/src/components/popup/countdown.js
+++ b/packages/tuya-panel-kit/src/components/popup/countdown.js
@@ -11,6 +11,7 @@ import {
   StyledOverview,
   StyledPickerUnitText,
   StyledCountdownContent,
+  StyledCountdownOnePickerContent
 } from './styled';
 
 const { toFixed } = CoreUtils;
@@ -215,7 +216,7 @@ class CountdownPopup extends React.Component {
               style={[countdownWrapperStyle, !switchValue && { opacity: 0.6 }]}
               pointerEvents={!switchValue ? 'none' : 'auto'}
             >
-              <StyledCountdownContent>
+              <StyledCountdownOnePickerContent>
                 <StyledOverview style={{ flex: 1 }}>
                   <Picker
                     theme={{ fontColor: countFontColor }}
@@ -235,7 +236,7 @@ class CountdownPopup extends React.Component {
                     text={minuteText}
                   />
                 </StyledOverview>
-              </StyledCountdownContent>
+              </StyledCountdownOnePickerContent>
             </StyledCountdownContainer>
           );
         }}

--- a/packages/tuya-panel-kit/src/components/popup/countdown.js
+++ b/packages/tuya-panel-kit/src/components/popup/countdown.js
@@ -21,6 +21,7 @@ const { getTheme, ThemeConsumer } = ThemeUtils;
 
 class CountdownPopup extends React.Component {
   static propTypes = {
+    ...Picker.PropTypes,
     /**
      * 外部样式
      */
@@ -204,6 +205,7 @@ class CountdownPopup extends React.Component {
       minuteText,
       minutePickerStyle,
       minuteUnitStyle,
+      ...rest
     } = this.props;
     return (
       <ThemeConsumer>
@@ -219,6 +221,7 @@ class CountdownPopup extends React.Component {
               <StyledCountdownOnePickerContent>
                 <StyledOverview style={{ flex: 1 }}>
                   <Picker
+                    {...rest}
                     theme={{ fontColor: countFontColor }}
                     accessibilityLabel="Popup_CountdownPicker_Minutes"
                     style={StyleSheet.flatten([{ width, height: 220 }, minutePickerStyle])}
@@ -258,6 +261,7 @@ class CountdownPopup extends React.Component {
       hourUnitStyle,
       minutePickerStyle,
       minuteUnitStyle,
+      ...rest
     } = this.props;
     const isMaxHour = this.state.hour === parseInt(max / 60, 10);
     const isMinHour = this.state.hour === parseInt(min / 60, 10);
@@ -290,6 +294,7 @@ class CountdownPopup extends React.Component {
                   }}
                 >
                   <Picker
+                    {...rest}
                     theme={{ fontColor: countFontColor }}
                     accessibilityLabel="Popup_CountdownPicker_Hours"
                     style={StyleSheet.flatten([
@@ -319,6 +324,7 @@ class CountdownPopup extends React.Component {
 
                 <StyledOverview style={{ flex: 1 }}>
                   <Picker
+                    {...rest}
                     theme={{ fontColor: countFontColor }}
                     accessibilityLabel="Popup_CountdownPicker_Minutes"
                     selectedValue={this.state.minute}

--- a/packages/tuya-panel-kit/src/components/popup/styled.js
+++ b/packages/tuya-panel-kit/src/components/popup/styled.js
@@ -237,6 +237,12 @@ export const StyledCountdownContent = styled(View)`
   background-color: ${cellBg};
 `;
 
+export const StyledCountdownOnePickerContent = styled(View)`
+  flex-direction: row;
+  align-items: center;
+  background-color: ${cellBg};
+`;
+
 export const StyledOverview = styled(View)`
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
## Description

when onlyone is true, Popup.countdown is not center.

## Type of change

Please select the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
