### PR TITLE
fix: 修复三方手势库在android端无效

### DIFF
--- a/packages/tuya-panel-kit/src/components/layout/full-view/index.js
+++ b/packages/tuya-panel-kit/src/components/layout/full-view/index.js
@@ -2,6 +2,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { View, Image, Dimensions, StyleSheet, ViewPropTypes, Platform, Text } from 'react-native';
+import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 import { Rect } from 'react-native-svg';
 import { TYSdk, Strings } from '../../../TYNativeApi';
 import TopBar from '../topbar';
@@ -383,4 +384,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default withTheme(FullView);
+export default withTheme(gestureHandlerRootHOC(FullView));


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes. If it is related to an issue, please bring the issue number, like `fixes #${number}`.
手势库在android无效，最终定位到android端需要在三方库组件上层包一层 GestureHandlerRootView 组件，用于android端分发触摸事件，但是tuya-panel-kit依赖的react-native-gesture-handler@1.3.0没有导出 GestureHandlerRootView，只提供了一个高阶函数gestureHandlerRootHOC，所以添加此pr抹除此差异
## Type of change

Please select the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
