### PR TITLE
fix(Popup.countdowm): fix minutes not being set to 0 when useTYRCTPicker is true and countdown clock is set to Max, fixes #155

### DIFF
--- a/example/tuya-panel-kit/src/pages/feedback/popup/index.tsx
+++ b/example/tuya-panel-kit/src/pages/feedback/popup/index.tsx
@@ -32,6 +32,7 @@ export default () => {
               minuteText: Strings.getLang('text_minute'),
               value: state.countdown,
               onMaskPress: ({ close }) => close(),
+              // useTYRCTPicker: true,
               onConfirm: (data, { close }) => {
                 setState({ countdown: data.hour * 60 + data.minute });
                 close();

--- a/packages/tuya-panel-kit/src/components/picker-view/TYRCTPicker.js
+++ b/packages/tuya-panel-kit/src/components/picker-view/TYRCTPicker.js
@@ -108,7 +108,7 @@ export class PickerView extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this._stateFromProps(nextProps);
+    this.setState(this._stateFromProps(nextProps));
   }
 
   _stateFromProps = props => {


### PR DESCRIPTION
## Description

fix minutes not being set to 0 when useTYRCTPicker is true and countdown clock is set to Max, fixes #155

## Type of change

Please select the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
