### PR TITLE
fix(Notification): Fixed Notification not centered in IOS, fixed #173

### DIFF
--- a/packages/tuya-panel-kit/src/components/notification/index.js
+++ b/packages/tuya-panel-kit/src/components/notification/index.js
@@ -138,7 +138,12 @@ export default class Notification extends PureComponent {
                     {imageSource ? (
                       <StyledImage source={imageSource} style={imageStyle} />
                     ) : (
-                      <StyledIconFont d={iconPath} color={iconColor} size={20} />
+                      <StyledIconFont
+                        d={iconPath}
+                        color={iconColor}
+                        size={20}
+                        enableClose={enableClose}
+                      />
                     )}
                     {children || (
                       <StyledTitle

--- a/packages/tuya-panel-kit/src/components/notification/styled.js
+++ b/packages/tuya-panel-kit/src/components/notification/styled.js
@@ -40,7 +40,7 @@ export const StyledTitle = styled(TYText)`
 
 export const StyledIconFont = styled(IconFont)`
   position: absolute;
-  top: ${cx(3)}px;
+  top: ${props => (props.enableClose ? cx(2) : 0)}px;
 `;
 
 export const StyledImage = styled(Image)`


### PR DESCRIPTION
## Description

Fixed Notification not centered in IOS, fixes #137 .

## Type of change

Please select the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
