### PR TITLE
feat(Dialog): The dialog.prompt confirmation button is highlighted by default, and new properties support changing the highlighted properties

### DIFF
--- a/packages/tuya-panel-kit/src/components/dialog/__tests__/__snapshots__/prompt.test.js.snap
+++ b/packages/tuya-panel-kit/src/components/dialog/__tests__/__snapshots__/prompt.test.js.snap
@@ -27,6 +27,7 @@ exports[`Prompt Component basic render defaultValue 1`] = `
     cancelText="取消"
     cancelTextStyle={null}
     confirmAccessibilityLabel="Dialog.Confirm"
+    confirmDisabled={false}
     confirmText="确认"
     confirmTextStyle={null}
     contentStyle={null}
@@ -411,7 +412,7 @@ exports[`Prompt Component basic render value 1`] = `
                 },
                 Array [
                   Object {
-                    "opacity": 0.3,
+                    "opacity": 1,
                   },
                   null,
                 ],

--- a/packages/tuya-panel-kit/src/components/dialog/prompt.js
+++ b/packages/tuya-panel-kit/src/components/dialog/prompt.js
@@ -84,6 +84,10 @@ class Prompt extends Component {
      * 确认回调函数
      */
     onConfirm: PropTypes.func,
+    /**
+     * 当输入内容为空时，确认按钮置灰，默认不置灰
+     */
+    confirmDisabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -105,6 +109,7 @@ class Prompt extends Component {
       initScale: 1,
       finalScale: 1,
     },
+    confirmDisabled: false,
   };
 
   constructor(props) {
@@ -167,11 +172,15 @@ class Prompt extends Component {
       cancelTextStyle,
       cancelAccessibilityLabel,
       onCancel,
+      confirmDisabled: confirmDisabledProps,
       ...TextInputProps
     } = this.props;
     const confirmDisabled =
-      (typeof value !== 'undefined' && this.state.value) ||
-      (typeof defaultValue !== 'undefined' && this.state.unControlledValue);
+      confirmDisabledProps &&
+      !(
+        (typeof value !== 'undefined' && this.state.value) ||
+        (typeof defaultValue !== 'undefined' && this.state.unControlledValue)
+      );
     return (
       <StyledContainer style={style}>
         <StyledContent
@@ -207,14 +216,14 @@ class Prompt extends Component {
         <Footer
           style={footerWrapperStyle}
           cancelTextStyle={cancelTextStyle}
-          confirmTextStyle={[{ opacity: confirmDisabled ? 1 : 0.3 }, confirmTextStyle]}
+          confirmTextStyle={[{ opacity: confirmDisabled ? 0.3 : 1 }, confirmTextStyle]}
           cancelText={cancelText}
           confirmText={confirmText}
           cancelAccessibilityLabel={cancelAccessibilityLabel}
           confirmAccessibilityLabel={confirmAccessibilityLabel}
           onCancel={onCancel}
           onConfirm={this._handleConfirm}
-          confirmDisabled={!confirmDisabled}
+          confirmDisabled={confirmDisabled}
         />
       </StyledContainer>
     );


### PR DESCRIPTION

## Description

The dialog.prompt confirmation button is highlighted by default, and new properties support changing the highlighted properties

## Type of change

Please select the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
