### PR TITLE
fix(Popup.countdown): When type = dark, the popup. countdown background color is white and looks blank

### DIFF
--- a/packages/tuya-panel-kit/src/components/popup/__tests__/__snapshots__/countdown.test.js.snap
+++ b/packages/tuya-panel-kit/src/components/popup/__tests__/__snapshots__/countdown.test.js.snap
@@ -250,6 +250,7 @@ exports[`countdown Component basic render 1`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginRight": 0,
                 "width": 465,
               }
@@ -452,6 +453,7 @@ exports[`countdown Component basic render 1`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginLeft": -225,
                 "width": 600,
               }
@@ -1218,6 +1220,7 @@ exports[`countdown Component basic render 2`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginRight": 0,
                 "width": 465,
               }
@@ -1420,6 +1423,7 @@ exports[`countdown Component basic render 2`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginLeft": -225,
                 "width": 600,
               }
@@ -2184,6 +2188,7 @@ exports[`countdown Component basic update 1`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginRight": 0,
                 "width": 465,
               }
@@ -2386,6 +2391,7 @@ exports[`countdown Component basic update 1`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginLeft": -225,
                 "width": 600,
               }
@@ -3150,6 +3156,7 @@ exports[`countdown Component basic update 2`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginRight": 0,
                 "width": 465,
               }
@@ -3352,6 +3359,7 @@ exports[`countdown Component basic update 2`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginLeft": -225,
                 "width": 600,
               }
@@ -4035,6 +4043,7 @@ exports[`countdown Component render width hour 1`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginRight": 0,
                 "width": 465,
               }
@@ -4117,6 +4126,7 @@ exports[`countdown Component render width hour 1`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginLeft": -225,
                 "width": 600,
               }
@@ -4750,6 +4760,7 @@ exports[`countdown Component render width hour 2`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginRight": 0,
                 "width": 465,
               }
@@ -4837,6 +4848,7 @@ exports[`countdown Component render width hour 2`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginLeft": -225,
                 "width": 600,
               }
@@ -5420,6 +5432,7 @@ exports[`countdown Component render width hour 3`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginRight": 0,
                 "width": 465,
               }
@@ -5507,6 +5520,7 @@ exports[`countdown Component render width hour 3`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "marginLeft": -225,
                 "width": 600,
               }
@@ -6138,6 +6152,7 @@ exports[`countdown Component render width onlyone 1`] = `
           <View
             style={
               Object {
+                "backgroundColor": "#FFF",
                 "height": 220,
                 "width": 750,
               }

--- a/packages/tuya-panel-kit/src/components/popup/countdown.js
+++ b/packages/tuya-panel-kit/src/components/popup/countdown.js
@@ -224,7 +224,7 @@ class CountdownPopup extends React.Component {
                     {...rest}
                     theme={{ fontColor: countFontColor }}
                     accessibilityLabel="Popup_CountdownPicker_Minutes"
-                    style={StyleSheet.flatten([{ width, height: 220 }, minutePickerStyle])}
+                    style={StyleSheet.flatten([{ width, height: 220, backgroundColor: getTheme(countdownTheme, 'popup.cellBg', '#FFF') }, minutePickerStyle])}
                     selectedValue={this.state.minute}
                     onValueChange={this.handleMinuteChange}
                   >
@@ -301,6 +301,7 @@ class CountdownPopup extends React.Component {
                       {
                         width: isIos ? width * (7 / 10) - 60 : width * (1 / 2),
                         marginRight: isIos ? 0 : cx(20),
+                        backgroundColor: getTheme(countdownTheme, 'popup.cellBg', '#FFF')
                       },
                       hourPickerStyle,
                     ])}
@@ -340,6 +341,7 @@ class CountdownPopup extends React.Component {
                             width: width * (1 / 2),
                             marginRight: cx(40),
                           },
+                          { backgroundColor: getTheme(countdownTheme, 'popup.cellBg', '#FFF') },
                       minutePickerStyle,
                     ])}
                   >


### PR DESCRIPTION
## Description

When type = dark, the popup. countdown background color is white and looks blank

## Type of change

Please select the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
